### PR TITLE
Fix Windows Firefox bridge setup support

### DIFF
--- a/.github/scripts/windows_bridge_smoke.ps1
+++ b/.github/scripts/windows_bridge_smoke.ps1
@@ -75,13 +75,13 @@ $hostStart.RedirectStandardOutput = $true
 $hostStart.RedirectStandardError = $true
 $hostStart.CreateNoWindow = $true
 $hostStart.Environment["FAB_REQUEST_TIMEOUT_MS"] = "5000"
-$host = [System.Diagnostics.Process]::Start($hostStart)
+$hostProc = [System.Diagnostics.Process]::Start($hostStart)
 
 try {
     Start-Sleep -Milliseconds 500
-    if ($host.HasExited) {
-        $err = $host.StandardError.ReadToEnd()
-        throw "Host exited early with code $($host.ExitCode): $err"
+    if ($hostProc.HasExited) {
+        $err = $hostProc.StandardError.ReadToEnd()
+        throw "Host exited early with code $($hostProc.ExitCode): $err"
     }
 
     $clientStart = New-Object System.Diagnostics.ProcessStartInfo
@@ -93,7 +93,7 @@ try {
     $clientStart.CreateNoWindow = $true
     $client = [System.Diagnostics.Process]::Start($clientStart)
 
-    $nativeMessage = Read-NativeMessage $host.StandardOutput.BaseStream
+    $nativeMessage = Read-NativeMessage $hostProc.StandardOutput.BaseStream
     if ($nativeMessage.action -ne "ping") {
         throw "Expected native ping action, got: $($nativeMessage | ConvertTo-Json -Depth 32 -Compress)"
     }
@@ -101,7 +101,7 @@ try {
         throw "Native ping message did not include an id"
     }
 
-    Write-NativeMessage $host.StandardInput.BaseStream @{
+    Write-NativeMessage $hostProc.StandardInput.BaseStream @{
         id = $nativeMessage.id
         ok = $true
         result = @{ pong = $true }
@@ -122,8 +122,8 @@ try {
 
     Write-Host "Windows native host smoke test passed"
 } finally {
-    if ($host -and -not $host.HasExited) {
-        $host.Kill()
-        $host.WaitForExit(5000) | Out-Null
+    if ($hostProc -and -not $hostProc.HasExited) {
+        $hostProc.Kill()
+        $hostProc.WaitForExit(5000) | Out-Null
     }
 }

--- a/.github/scripts/windows_bridge_smoke.ps1
+++ b/.github/scripts/windows_bridge_smoke.ps1
@@ -1,0 +1,129 @@
+param(
+    [string]$Target = "x86_64-pc-windows-msvc"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$RustCli = Join-Path $RepoRoot "rust-cli"
+$BrowserExe = Join-Path $RustCli "target\$Target\release\browser.exe"
+$HostExe = Join-Path $RustCli "target\$Target\release\firefox-agent-bridge-host.exe"
+
+if (-not (Test-Path $BrowserExe)) {
+    throw "browser.exe not found at $BrowserExe"
+}
+if (-not (Test-Path $HostExe)) {
+    throw "firefox-agent-bridge-host.exe not found at $HostExe"
+}
+
+function Read-Exact([System.IO.Stream]$Stream, [int]$Count) {
+    $buffer = New-Object byte[] $Count
+    $offset = 0
+    while ($offset -lt $Count) {
+        $read = $Stream.Read($buffer, $offset, $Count - $offset)
+        if ($read -le 0) {
+            throw "Unexpected EOF while reading $Count bytes; got $offset"
+        }
+        $offset += $read
+    }
+    return $buffer
+}
+
+function Read-NativeMessage([System.IO.Stream]$Stream) {
+    $lenBytes = Read-Exact $Stream 4
+    $len = [BitConverter]::ToUInt32($lenBytes, 0)
+    if ($len -le 0 -or $len -gt 10485760) {
+        throw "Invalid native message length: $len"
+    }
+    $payloadBytes = Read-Exact $Stream ([int]$len)
+    $payload = [System.Text.Encoding]::UTF8.GetString($payloadBytes)
+    return $payload | ConvertFrom-Json
+}
+
+function Write-NativeMessage([System.IO.Stream]$Stream, [object]$Message) {
+    $json = $Message | ConvertTo-Json -Depth 32 -Compress
+    $payloadBytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+    $lenBytes = [BitConverter]::GetBytes([UInt32]$payloadBytes.Length)
+    $Stream.Write($lenBytes, 0, $lenBytes.Length)
+    $Stream.Write($payloadBytes, 0, $payloadBytes.Length)
+    $Stream.Flush()
+}
+
+& $BrowserExe --version
+if ($LASTEXITCODE -ne 0) {
+    throw "browser.exe --version failed"
+}
+
+& $BrowserExe docs *> $null
+if ($LASTEXITCODE -ne 0) {
+    throw "browser.exe docs failed"
+}
+
+$session = & $BrowserExe session start windows-smoke 2>&1
+if ($LASTEXITCODE -eq 0) {
+    throw "browser.exe session start unexpectedly succeeded on Windows: $session"
+}
+if (($session -join "`n") -notmatch "not supported") {
+    throw "Windows session unsupported message was unclear: $session"
+}
+
+$hostStart = New-Object System.Diagnostics.ProcessStartInfo
+$hostStart.FileName = $HostExe
+$hostStart.UseShellExecute = $false
+$hostStart.RedirectStandardInput = $true
+$hostStart.RedirectStandardOutput = $true
+$hostStart.RedirectStandardError = $true
+$hostStart.CreateNoWindow = $true
+$hostStart.Environment["FAB_REQUEST_TIMEOUT_MS"] = "5000"
+$host = [System.Diagnostics.Process]::Start($hostStart)
+
+try {
+    Start-Sleep -Milliseconds 500
+    if ($host.HasExited) {
+        $err = $host.StandardError.ReadToEnd()
+        throw "Host exited early with code $($host.ExitCode): $err"
+    }
+
+    $clientStart = New-Object System.Diagnostics.ProcessStartInfo
+    $clientStart.FileName = $BrowserExe
+    $clientStart.Arguments = 'ping'
+    $clientStart.UseShellExecute = $false
+    $clientStart.RedirectStandardOutput = $true
+    $clientStart.RedirectStandardError = $true
+    $clientStart.CreateNoWindow = $true
+    $client = [System.Diagnostics.Process]::Start($clientStart)
+
+    $nativeMessage = Read-NativeMessage $host.StandardOutput.BaseStream
+    if ($nativeMessage.action -ne "ping") {
+        throw "Expected native ping action, got: $($nativeMessage | ConvertTo-Json -Depth 32 -Compress)"
+    }
+    if (-not $nativeMessage.id) {
+        throw "Native ping message did not include an id"
+    }
+
+    Write-NativeMessage $host.StandardInput.BaseStream @{
+        id = $nativeMessage.id
+        ok = $true
+        result = @{ pong = $true }
+    }
+
+    if (-not $client.WaitForExit(10000)) {
+        $client.Kill()
+        throw "browser.exe ping did not exit after fake native response"
+    }
+    $clientOut = $client.StandardOutput.ReadToEnd()
+    $clientErr = $client.StandardError.ReadToEnd()
+    if ($client.ExitCode -ne 0) {
+        throw "browser.exe ping failed with code $($client.ExitCode). stdout=$clientOut stderr=$clientErr"
+    }
+    if ($clientOut -notmatch '"pong"\s*:\s*true') {
+        throw "browser.exe ping did not print pong result. stdout=$clientOut stderr=$clientErr"
+    }
+
+    Write-Host "Windows native host smoke test passed"
+} finally {
+    if ($host -and -not $host.HasExited) {
+        $host.Kill()
+        $host.WaitForExit(5000) | Out-Null
+    }
+}

--- a/.github/scripts/windows_bridge_smoke.ps1
+++ b/.github/scripts/windows_bridge_smoke.ps1
@@ -127,3 +127,5 @@ try {
         $hostProc.WaitForExit(5000) | Out-Null
     }
 }
+
+exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,21 +24,27 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: browser-linux-x64
+            host_name: host-linux-x64
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             name: browser-linux-x64-musl
+            host_name: host-linux-x64-musl
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             name: browser-linux-arm64
+            host_name: host-linux-arm64
           - target: x86_64-apple-darwin
             os: macos-latest
             name: browser-macos-x64
+            host_name: host-macos-x64
           - target: aarch64-apple-darwin
             os: macos-latest
             name: browser-macos-arm64
+            host_name: host-macos-arm64
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: browser-windows-x64.exe
+            host_name: host-windows-x64.exe
 
     steps:
       - uses: actions/checkout@v4
@@ -70,18 +76,23 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cp rust-cli/target/${{ matrix.target }}/release/browser ${{ matrix.name }}
+          cp rust-cli/target/${{ matrix.target }}/release/firefox-agent-bridge-host ${{ matrix.host_name }}
           chmod +x ${{ matrix.name }}
+          chmod +x ${{ matrix.host_name }}
 
       - name: Prepare artifact (Windows)
         if: runner.os == 'Windows'
         run: |
           copy rust-cli\target\${{ matrix.target }}\release\browser.exe ${{ matrix.name }}
+          copy rust-cli\target\${{ matrix.target }}\release\firefox-agent-bridge-host.exe ${{ matrix.host_name }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.name }}
-          path: ${{ matrix.name }}
+          name: ${{ matrix.target }}-binaries
+          path: |
+            ${{ matrix.name }}
+            ${{ matrix.host_name }}
 
   release:
     name: Create Release
@@ -142,6 +153,17 @@ jobs:
             | macOS Intel | `browser-macos-x64` |
             | macOS Apple Silicon | `browser-macos-arm64` |
             | Windows x64 | `browser-windows-x64.exe` |
+
+            Native messaging host binaries are also attached for automated setup:
+
+            | Platform | Host binary |
+            |----------|-------------|
+            | Linux x64 | `host-linux-x64` |
+            | Linux x64 (static) | `host-linux-x64-musl` |
+            | Linux ARM64 | `host-linux-arm64` |
+            | macOS Intel | `host-macos-x64` |
+            | macOS Apple Silicon | `host-macos-arm64` |
+            | Windows x64 | `host-windows-x64.exe` |
 
             **Quick install (Linux/macOS):**
             ```bash

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -1,0 +1,37 @@
+name: Windows Smoke
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  windows-smoke:
+    name: Windows native host smoke
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust-cli
+          key: windows-smoke-x86_64-pc-windows-msvc
+
+      - name: Build Windows binaries
+        working-directory: rust-cli
+        run: cargo build --release --target x86_64-pc-windows-msvc
+
+      - name: Run Windows bridge smoke test
+        shell: pwsh
+        run: ./.github/scripts/windows_bridge_smoke.ps1 -Target x86_64-pc-windows-msvc

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ cd ..
 ./scripts/install-native-host.sh
 ```
 
+### Windows support
+
+Windows is supported for the core Firefox bridge flow when both release binaries are installed:
+
+- `browser-windows-x64.exe` - CLI client
+- `host-windows-x64.exe` - Firefox native messaging host
+
+Firefox still requires a native messaging host manifest registered under
+`HKCU\Software\Mozilla\NativeMessagingHosts\firefox_agent_bridge`. Downstream installers such as
+`jcode browser setup` can stage the host binary, write the manifest, and create this registry entry.
+
+Known limitation: persistent `browser session ...` mode currently uses Unix-domain sockets and is
+disabled on Windows. Direct one-shot browser commands and the native messaging host are expected to
+compile and run on Windows.
+
 ### 3. Install the CLI
 
 ```bash

--- a/rust-cli/Cargo.lock
+++ b/rust-cli/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
 [[package]]
 name = "bronzewarden"
 version = "0.1.0"
+source = "git+https://github.com/1jehuang/bronzewarden.git#839dd2b97d11a3009e47ffc514f5286c8eb2a124"
 dependencies = [
  "aes",
  "anyhow",

--- a/rust-cli/Cargo.toml
+++ b/rust-cli/Cargo.toml
@@ -44,7 +44,7 @@ anyhow = "1"
 dirs = "5"
 
 # Vault credential lookup
-bronzewarden = { path = "../../projects/bronzewarden" }
+bronzewarden = { git = "https://github.com/1jehuang/bronzewarden.git" }
 rpassword = "7"
 
 [dev-dependencies]

--- a/rust-cli/src/commands/session.rs
+++ b/rust-cli/src/commands/session.rs
@@ -1,23 +1,45 @@
 use anyhow::{anyhow, Result};
+#[cfg(unix)]
 use futures_util::{SinkExt, StreamExt};
-use serde_json::{json, Value};
+#[cfg(unix)]
+use serde_json::json;
+use serde_json::Value;
 use std::path::PathBuf;
+#[cfg(unix)]
 use std::sync::Arc;
+#[cfg(unix)]
 use std::time::Duration;
+#[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::{TcpStream, UnixListener, UnixStream};
+#[cfg(unix)]
+use tokio::net::TcpStream;
+#[cfg(unix)]
+use tokio::net::{UnixListener, UnixStream};
+#[cfg(unix)]
 use tokio::sync::{mpsc, Mutex};
+#[cfg(unix)]
 use tokio::time::timeout;
+#[cfg(unix)]
 use tokio_tungstenite::tungstenite::Message;
+#[cfg(unix)]
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
+#[cfg(unix)]
 use crate::config::{TIMEOUT_MS, WS_URL};
 
 fn runtime_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
-        PathBuf::from(dir)
-    } else {
-        PathBuf::from("/tmp")
+    #[cfg(windows)]
+    {
+        return std::env::temp_dir();
+    }
+
+    #[cfg(not(windows))]
+    {
+        if let Ok(dir) = std::env::var("XDG_RUNTIME_DIR") {
+            PathBuf::from(dir)
+        } else {
+            PathBuf::from("/tmp")
+        }
     }
 }
 
@@ -37,20 +59,31 @@ fn cleanup_socket(name: &str) {
 }
 
 pub fn is_session_running(name: &str) -> bool {
-    let pid_path = session_pid_path(name);
-    if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
-        if let Ok(pid) = pid_str.trim().parse::<u32>() {
-            let proc_path = format!("/proc/{}", pid);
-            if std::path::Path::new(&proc_path).exists() {
-                return true;
+    #[cfg(windows)]
+    {
+        let _ = name;
+        return false;
+    }
+
+    #[cfg(not(windows))]
+    {
+        let pid_path = session_pid_path(name);
+        if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
+            if let Ok(pid) = pid_str.trim().parse::<u32>() {
+                let proc_path = format!("/proc/{}", pid);
+                if std::path::Path::new(&proc_path).exists() {
+                    return true;
+                }
             }
         }
+        false
     }
-    false
 }
 
+#[cfg(unix)]
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
+#[cfg(unix)]
 struct SessionState {
     ws_write: futures_util::stream::SplitSink<WsStream, Message>,
     pending: std::collections::HashMap<String, mpsc::Sender<Value>>,
@@ -59,140 +92,154 @@ struct SessionState {
 }
 
 pub async fn run(name: &str) -> Result<()> {
-    let sock_path = session_socket_path(name);
-    let pid_path = session_pid_path(name);
-
-    if sock_path.exists() {
-        if is_session_running(name) {
-            return Err(anyhow!("Session '{}' is already running", name));
-        }
-        cleanup_socket(name);
+    #[cfg(not(unix))]
+    {
+        let _ = name;
+        return Err(anyhow!(
+            "Persistent browser sessions are not supported on this platform yet. Use direct browser commands instead."
+        ));
     }
 
-    eprintln!("[session:{}] Connecting to browser bridge...", name);
+    #[cfg(unix)]
+    {
+        let sock_path = session_socket_path(name);
+        let pid_path = session_pid_path(name);
 
-    let (ws_stream, _) = connect_async(WS_URL).await.map_err(|e| {
-        anyhow!(
-            "WebSocket error: {}\nIs Firefox running with the Browser Agent Bridge extension?",
-            e
-        )
-    })?;
+        if sock_path.exists() {
+            if is_session_running(name) {
+                return Err(anyhow!("Session '{}' is already running", name));
+            }
+            cleanup_socket(name);
+        }
 
-    let (ws_write, mut ws_read) = ws_stream.split();
+        eprintln!("[session:{}] Connecting to browser bridge...", name);
 
-    let state = Arc::new(Mutex::new(SessionState {
-        ws_write,
-        pending: std::collections::HashMap::new(),
-        counter: 0,
-        session_id: None,
-    }));
+        let (ws_stream, _) = connect_async(WS_URL).await.map_err(|e| {
+            anyhow!(
+                "WebSocket error: {}\nIs Firefox running with the Browser Agent Bridge extension?",
+                e
+            )
+        })?;
 
-    // Read the ready message to get session ID
-    if let Some(Ok(Message::Text(text))) = ws_read.next().await {
-        if let Ok(msg) = serde_json::from_str::<Value>(&text) {
-            if msg.get("type").and_then(|v| v.as_str()) == Some("ready") {
-                let sid = msg.get("sessionId").and_then(|v| v.as_str()).map(|s| s.to_string());
-                state.lock().await.session_id = sid.clone();
-                eprintln!(
-                    "[session:{}] Connected (session: {})",
-                    name,
-                    sid.as_deref().unwrap_or("unknown")
-                );
+        let (ws_write, mut ws_read) = ws_stream.split();
+
+        let state = Arc::new(Mutex::new(SessionState {
+            ws_write,
+            pending: std::collections::HashMap::new(),
+            counter: 0,
+            session_id: None,
+        }));
+
+        // Read the ready message to get session ID
+        if let Some(Ok(Message::Text(text))) = ws_read.next().await {
+            if let Ok(msg) = serde_json::from_str::<Value>(&text) {
+                if msg.get("type").and_then(|v| v.as_str()) == Some("ready") {
+                    let sid = msg
+                        .get("sessionId")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    state.lock().await.session_id = sid.clone();
+                    eprintln!(
+                        "[session:{}] Connected (session: {})",
+                        name,
+                        sid.as_deref().unwrap_or("unknown")
+                    );
+                }
             }
         }
-    }
 
-    // Write PID file
-    std::fs::write(&pid_path, std::process::id().to_string())?;
+        // Write PID file
+        std::fs::write(&pid_path, std::process::id().to_string())?;
 
-    // Create Unix socket listener
-    let listener = UnixListener::bind(&sock_path)?;
-    eprintln!("[session:{}] Listening on {}", name, sock_path.display());
+        // Create Unix socket listener
+        let listener = UnixListener::bind(&sock_path)?;
+        eprintln!("[session:{}] Listening on {}", name, sock_path.display());
 
-    // Print ready JSON to stdout so callers can detect startup
-    println!(
-        "{}",
-        json!({
-            "ready": true,
-            "session": name,
-            "socket": sock_path.to_string_lossy(),
-            "pid": std::process::id(),
-        })
-    );
+        // Print ready JSON to stdout so callers can detect startup
+        println!(
+            "{}",
+            json!({
+                "ready": true,
+                "session": name,
+                "socket": sock_path.to_string_lossy(),
+                "pid": std::process::id(),
+            })
+        );
 
-    // Task: read WebSocket responses and dispatch to pending requests
-    let state_ws = state.clone();
-    let ws_reader = tokio::spawn(async move {
-        while let Some(msg) = ws_read.next().await {
-            match msg {
-                Ok(Message::Text(text)) => {
-                    if let Ok(response) = serde_json::from_str::<Value>(&text) {
-                        if let Some(id) =
-                            response.get("id").and_then(|v| v.as_str()).map(|s| s.to_string())
-                        {
-                            let tx = state_ws.lock().await.pending.remove(&id);
-                            if let Some(tx) = tx {
-                                let _ = tx.send(response).await;
+        // Task: read WebSocket responses and dispatch to pending requests
+        let state_ws = state.clone();
+        let ws_reader = tokio::spawn(async move {
+            while let Some(msg) = ws_read.next().await {
+                match msg {
+                    Ok(Message::Text(text)) => {
+                        if let Ok(response) = serde_json::from_str::<Value>(&text) {
+                            if let Some(id) = response
+                                .get("id")
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string())
+                            {
+                                let tx = state_ws.lock().await.pending.remove(&id);
+                                if let Some(tx) = tx {
+                                    let _ = tx.send(response).await;
+                                }
                             }
                         }
                     }
-                }
-                Ok(Message::Close(_)) => {
-                    eprintln!("[session] WebSocket closed by server");
-                    break;
-                }
-                Err(e) => {
-                    eprintln!("[session] WebSocket error: {}", e);
-                    break;
-                }
-                _ => {}
-            }
-        }
-    });
-
-    // Task: accept Unix socket connections and proxy commands
-    let state_accept = state.clone();
-    let name_owned = name.to_string();
-    let acceptor = tokio::spawn(async move {
-        loop {
-            match listener.accept().await {
-                Ok((stream, _)) => {
-                    let state_clone = state_accept.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = handle_unix_client(stream, state_clone).await {
-                            eprintln!("[session] Client error: {}", e);
-                        }
-                    });
-                }
-                Err(e) => {
-                    eprintln!("[session:{}] Accept error: {}", name_owned, e);
-                    break;
+                    Ok(Message::Close(_)) => {
+                        eprintln!("[session] WebSocket closed by server");
+                        break;
+                    }
+                    Err(e) => {
+                        eprintln!("[session] WebSocket error: {}", e);
+                        break;
+                    }
+                    _ => {}
                 }
             }
-        }
-    });
+        });
 
-    // Wait for either task to finish (WebSocket disconnect or signal)
-    tokio::select! {
-        _ = ws_reader => {
-            eprintln!("[session:{}] WebSocket reader exited", name);
+        // Task: accept Unix socket connections and proxy commands
+        let state_accept = state.clone();
+        let name_owned = name.to_string();
+        let acceptor = tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((stream, _)) => {
+                        let state_clone = state_accept.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = handle_unix_client(stream, state_clone).await {
+                                eprintln!("[session] Client error: {}", e);
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        eprintln!("[session:{}] Accept error: {}", name_owned, e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Wait for either task to finish (WebSocket disconnect or signal)
+        tokio::select! {
+            _ = ws_reader => {
+                eprintln!("[session:{}] WebSocket reader exited", name);
+            }
+            _ = acceptor => {
+                eprintln!("[session:{}] Acceptor exited", name);
+            }
+            _ = tokio::signal::ctrl_c() => {
+                eprintln!("[session:{}] Shutting down", name);
+            }
         }
-        _ = acceptor => {
-            eprintln!("[session:{}] Acceptor exited", name);
-        }
-        _ = tokio::signal::ctrl_c() => {
-            eprintln!("[session:{}] Shutting down", name);
-        }
+
+        cleanup_socket(name);
+        Ok(())
     }
-
-    cleanup_socket(name);
-    Ok(())
 }
 
-async fn handle_unix_client(
-    stream: UnixStream,
-    state: Arc<Mutex<SessionState>>,
-) -> Result<()> {
+#[cfg(unix)]
+async fn handle_unix_client(stream: UnixStream, state: Arc<Mutex<SessionState>>) -> Result<()> {
     let (read_half, mut write_half) = stream.into_split();
     let mut reader = BufReader::new(read_half);
 
@@ -204,14 +251,17 @@ async fn handle_unix_client(
             continue;
         }
 
-        let mut message: Value = serde_json::from_str(trimmed).map_err(|e| {
-            anyhow!("Invalid JSON: {}", e)
-        })?;
+        let mut message: Value =
+            serde_json::from_str(trimmed).map_err(|e| anyhow!("Invalid JSON: {}", e))?;
 
         let (id, rx) = {
             let mut st = state.lock().await;
             st.counter += 1;
-            let id = format!("sess_{}_{}", st.session_id.as_deref().unwrap_or("x"), st.counter);
+            let id = format!(
+                "sess_{}_{}",
+                st.session_id.as_deref().unwrap_or("x"),
+                st.counter
+            );
             message["id"] = json!(&id);
 
             let (tx, rx) = mpsc::channel::<Value>(1);
@@ -248,65 +298,86 @@ async fn handle_unix_client(
     Ok(())
 }
 
+#[cfg(unix)]
 async fn rx_recv_owned(mut rx: mpsc::Receiver<Value>) -> Option<Value> {
     rx.recv().await
 }
 
-pub async fn send_via_session(
-    session_name: &str,
-    action: &str,
-    params: Value,
-) -> Result<Value> {
-    let sock_path = session_socket_path(session_name);
-    if !sock_path.exists() {
+pub async fn send_via_session(session_name: &str, action: &str, params: Value) -> Result<Value> {
+    #[cfg(not(unix))]
+    {
+        let _ = (session_name, action, params);
         return Err(anyhow!(
-            "Session '{}' not running (no socket at {})",
-            session_name,
-            sock_path.display()
+            "Persistent browser sessions are not supported on this platform yet. Use direct browser commands instead."
         ));
     }
 
-    let stream = UnixStream::connect(&sock_path).await.map_err(|e| {
-        anyhow!("Failed to connect to session '{}': {}", session_name, e)
-    })?;
+    #[cfg(unix)]
+    {
+        let sock_path = session_socket_path(session_name);
+        if !sock_path.exists() {
+            return Err(anyhow!(
+                "Session '{}' not running (no socket at {})",
+                session_name,
+                sock_path.display()
+            ));
+        }
 
-    let (read_half, mut write_half) = stream.into_split();
+        let stream = UnixStream::connect(&sock_path)
+            .await
+            .map_err(|e| anyhow!("Failed to connect to session '{}': {}", session_name, e))?;
 
-    let request = json!({
-        "action": action,
-        "params": params,
-    });
+        let (read_half, mut write_half) = stream.into_split();
 
-    let mut msg = request.to_string();
-    msg.push('\n');
-    write_half.write_all(msg.as_bytes()).await?;
+        let request = json!({
+            "action": action,
+            "params": params,
+        });
 
-    let mut reader = BufReader::new(read_half);
-    let mut response_line = String::new();
-    let bytes_read = timeout(Duration::from_millis(TIMEOUT_MS), reader.read_line(&mut response_line))
+        let mut msg = request.to_string();
+        msg.push('\n');
+        write_half.write_all(msg.as_bytes()).await?;
+
+        let mut reader = BufReader::new(read_half);
+        let mut response_line = String::new();
+        let bytes_read = timeout(
+            Duration::from_millis(TIMEOUT_MS),
+            reader.read_line(&mut response_line),
+        )
         .await
         .map_err(|_| anyhow!("Timeout waiting for session response"))??;
 
-    if bytes_read == 0 {
-        return Err(anyhow!("Session closed connection"));
-    }
+        if bytes_read == 0 {
+            return Err(anyhow!("Session closed connection"));
+        }
 
-    let response: Value = serde_json::from_str(response_line.trim())?;
-    Ok(response)
+        let response: Value = serde_json::from_str(response_line.trim())?;
+        Ok(response)
+    }
 }
 
 pub async fn stop(name: &str) -> Result<()> {
-    let pid_path = session_pid_path(name);
-    if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
-        if let Ok(pid) = pid_str.trim().parse::<u32>() {
-            let _ = std::process::Command::new("kill")
-                .arg(pid.to_string())
-                .status();
-            eprintln!("Sent SIGTERM to session '{}' (pid {})", name, pid);
-        }
+    #[cfg(windows)]
+    {
+        cleanup_socket(name);
+        eprintln!("Persistent browser sessions are not supported on Windows; removed stale session files for '{}'.", name);
+        return Ok(());
     }
-    cleanup_socket(name);
-    Ok(())
+
+    #[cfg(not(windows))]
+    {
+        let pid_path = session_pid_path(name);
+        if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
+            if let Ok(pid) = pid_str.trim().parse::<u32>() {
+                let _ = std::process::Command::new("kill")
+                    .arg(pid.to_string())
+                    .status();
+                eprintln!("Sent SIGTERM to session '{}' (pid {})", name, pid);
+            }
+        }
+        cleanup_socket(name);
+        Ok(())
+    }
 }
 
 pub fn list() -> Result<()> {

--- a/rust-cli/src/commands/start.rs
+++ b/rust-cli/src/commands/start.rs
@@ -26,11 +26,26 @@ pub async fn run(url: Option<&str>, timeout_secs: u64) -> Result<()> {
 
     println!("Starting Firefox...");
 
-    // Build the firefox command
-    let mut cmd = Command::new("firefox");
-    if let Some(url) = url {
-        cmd.arg(url);
-    }
+    // Build the Firefox command. On Windows, Firefox is commonly registered in
+    // App Paths but not present on PATH, so use the shell's `start` resolution.
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "start", "", "firefox"]);
+        if let Some(url) = url {
+            cmd.arg(url);
+        }
+        cmd
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    let mut cmd = {
+        let mut cmd = Command::new("firefox");
+        if let Some(url) = url {
+            cmd.arg(url);
+        }
+        cmd
+    };
 
     // Spawn Firefox in background (detached)
     cmd.stdout(std::process::Stdio::null())


### PR DESCRIPTION
Fixes jcode issue 201 by making Windows bridge artifacts and smoke coverage real.

Changes:
- Publish native host assets, including host-windows-x64.exe.
- Disable unsupported persistent session socket mode on Windows while keeping direct CLI/native-host bridge supported.
- Add a Windows smoke workflow that launches the real host and browser CLI, intercepts native messaging frames, injects a fake Firefox response, and verifies browser ping receives pong.
- Replace local-only bronzewarden path dependency with the public Git dependency so clean CI/release runners can build.
- Use Windows shell app resolution for browser start.

Validation run locally:
- cargo check --bins --target x86_64-pc-windows-msvc
- cargo check --bins
- PowerShell parser check for .github/scripts/windows_bridge_smoke.ps1