### PR TITLE
feat: honor FAB_WS_HOST/FAB_WS_PORT in browser CLI

### DIFF
--- a/rust-cli/src/client.rs
+++ b/rust-cli/src/client.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
-use crate::config::{TIMEOUT_MS, WS_URL};
+use crate::config::{ws_url, TIMEOUT_MS};
 use crate::protocol::{Request, Response};
 
 /// Timing breakdown for a command
@@ -31,7 +31,7 @@ pub async fn send_command_timed(action: &str, params: Value) -> Result<TimedResp
     let start = Instant::now();
 
     // Connect to WebSocket
-    let (ws_stream, _) = connect_async(WS_URL).await.map_err(|e| {
+    let (ws_stream, _) = connect_async(ws_url()).await.map_err(|e| {
         anyhow!(
             "WebSocket error: {}\nIs Firefox running with the Browser Agent Bridge extension enabled?",
             e

--- a/rust-cli/src/commands/session.rs
+++ b/rust-cli/src/commands/session.rs
@@ -25,7 +25,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
 #[cfg(unix)]
-use crate::config::{TIMEOUT_MS, WS_URL};
+use crate::config::{ws_url, TIMEOUT_MS};
 
 fn runtime_dir() -> PathBuf {
     #[cfg(windows)]
@@ -114,7 +114,7 @@ pub async fn run(name: &str, bind_window: bool) -> Result<()> {
 
         eprintln!("[session:{}] Connecting to browser bridge...", name);
 
-        let (ws_stream, _) = connect_async(WS_URL).await.map_err(|e| {
+        let (ws_stream, _) = connect_async(ws_url()).await.map_err(|e| {
             anyhow!(
                 "WebSocket error: {}\nIs Firefox running with the Browser Agent Bridge extension?",
                 e

--- a/rust-cli/src/commands/start.rs
+++ b/rust-cli/src/commands/start.rs
@@ -6,11 +6,11 @@ use std::time::{Duration, Instant};
 use tokio::time::sleep;
 use tokio_tungstenite::connect_async;
 
-use crate::config::WS_URL;
+use crate::config::ws_url;
 
 /// Check if we can connect to the WebSocket server
 async fn is_connected() -> bool {
-    match connect_async(WS_URL).await {
+    match connect_async(ws_url()).await {
         Ok((_, _)) => true,
         Err(_) => false,
     }

--- a/rust-cli/src/config.rs
+++ b/rust-cli/src/config.rs
@@ -1,5 +1,24 @@
-/// WebSocket URL to connect to the Firefox extension via native host
-pub const WS_URL: &str = "ws://127.0.0.1:8766";
+use std::env;
+
+/// Default WebSocket host the native host binds to.
+const DEFAULT_WS_HOST: &str = "127.0.0.1";
+/// Default WebSocket port the native host binds to.
+const DEFAULT_WS_PORT: u16 = 8766;
+
+/// WebSocket URL to connect to the Firefox extension via native host.
+///
+/// Honors `FAB_WS_HOST` / `FAB_WS_PORT` so the CLI can follow the native host
+/// when it is moved off the default port (e.g. to avoid a port collision).
+/// These are the same env vars the host reads, so setting them once keeps both
+/// ends in sync.
+pub fn ws_url() -> String {
+    let host = env::var("FAB_WS_HOST").unwrap_or_else(|_| DEFAULT_WS_HOST.to_string());
+    let port = env::var("FAB_WS_PORT")
+        .ok()
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(DEFAULT_WS_PORT);
+    format!("ws://{host}:{port}")
+}
 
 /// Timeout for WebSocket responses in milliseconds
 pub const TIMEOUT_MS: u64 = 30000;


### PR DESCRIPTION
## Summary

The native host already reads `FAB_WS_HOST`/`FAB_WS_PORT` to choose where its WebSocket server binds (see `ws_host()`/`ws_port()` in `src/bin/host.rs`), but the CLI client hard-coded `ws://127.0.0.1:8766` via the `WS_URL` const. That made it impossible to move the bridge off 8766 when another service already owns the port — the host could be relocated, but the CLI could no longer reach it.

This replaces the `WS_URL` const with a `ws_url()` resolver that reads the **same** env vars (default `127.0.0.1:8766`), so both ends stay in sync from a single `FAB_WS_PORT`/`FAB_WS_HOST` setting.

## Changes
- `src/config.rs`: add `ws_url()` reading `FAB_WS_HOST`/`FAB_WS_PORT` (defaults unchanged: 127.0.0.1:8766)
- `src/client.rs`, `src/commands/session.rs`, `src/commands/start.rs`: use `ws_url()` instead of the removed const

## Motivation
Hit a real port collision on macOS where another launchd service owned 8766. With this change the whole bridge can be moved with one env var instead of a recompile.

## Test plan
- [x] `cargo build --release` clean
- [x] With host + CLI both on default: `browser ping` → `{"pong": true}`, `browser getContent` → live tab HTML
- [x] Verified host honors `FAB_WS_PORT` (host log: `WebSocket server listening on ws://127.0.0.1:<port>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)