### PR TITLE
fix: navigate() hangs 15s on hash/same-document navigations

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -642,7 +642,7 @@ async function executeParallel(params, profile) {
 
       // Wait for page load if URL provided
       if (branch.url) {
-        await waitForTabComplete(tab.id, branch.timeoutMs || 15000);
+        await waitForTabComplete(tab.id, branch.timeoutMs || 15000, branch.url);
         // Small delay for content script
         await new Promise(r => setTimeout(r, 100));
       }
@@ -1006,26 +1006,85 @@ async function listForks() {
   return { forks, count: forks.length };
 }
 
-async function waitForTabComplete(tabId, timeoutMs = 15000) {
+async function waitForTabComplete(tabId, timeoutMs = 15000, expectedUrl = null) {
+  // Normalize an expected URL for same-document detection (compare ignoring the
+  // hash so we can tell a hash-only change apart from a full navigation).
+  function stripHash(u) {
+    if (!u) return null;
+    try {
+      const parsed = new URL(u);
+      parsed.hash = "";
+      return parsed.href;
+    } catch (_e) {
+      return u;
+    }
+  }
+  const expectedNoHash = stripHash(expectedUrl);
+  const expectedHasHash = !!(expectedUrl && expectedUrl.includes("#"));
+
   return new Promise((resolve, reject) => {
+    let settled = false;
+
     const timer = setTimeout(() => {
       cleanup();
       reject(new Error("Timed out waiting for page load"));
     }, timeoutMs);
 
+    function finish() {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve({ tabId });
+    }
+
+    // Full document loads fire tabs.onUpdated with status === "complete".
     function onUpdated(updatedTabId, info) {
       if (updatedTabId === tabId && info.status === "complete") {
-        cleanup();
-        resolve({ tabId });
+        finish();
       }
+    }
+
+    // Same-document navigations (hash change, history.pushState) never emit a
+    // "complete" status, so tabs.onUpdated alone would hang until timeout.
+    // webNavigation surfaces them via dedicated events. Match the tab and, when
+    // we know the target, the destination URL (ignoring hash) so we don't
+    // resolve on an unrelated in-page navigation.
+    function onSameDocument(details) {
+      if (details.tabId !== tabId || details.frameId !== 0) return;
+      if (expectedNoHash && stripHash(details.url) !== expectedNoHash) return;
+      finish();
     }
 
     function cleanup() {
       clearTimeout(timer);
       browser.tabs.onUpdated.removeListener(onUpdated);
+      if (browser.webNavigation) {
+        browser.webNavigation.onReferenceFragmentUpdated.removeListener(onSameDocument);
+        browser.webNavigation.onHistoryStateUpdated.removeListener(onSameDocument);
+      }
     }
 
     browser.tabs.onUpdated.addListener(onUpdated);
+    if (browser.webNavigation) {
+      browser.webNavigation.onReferenceFragmentUpdated.addListener(onSameDocument);
+      browser.webNavigation.onHistoryStateUpdated.addListener(onSameDocument);
+    }
+
+    // Pre-check: the navigation may already be finished before the listeners
+    // were attached (fast/cached loads, or a hash-only change that Firefox
+    // applied synchronously). Resolve immediately in that case so we never wait
+    // for an event that has already fired.
+    browser.tabs.get(tabId).then((tab) => {
+      if (!tab) return;
+      const currentNoHash = stripHash(tab.url);
+      const urlMatches =
+        !expectedUrl ||
+        tab.url === expectedUrl ||
+        (expectedHasHash && currentNoHash === expectedNoHash);
+      if (tab.status === "complete" && urlMatches) {
+        finish();
+      }
+    }).catch(() => {});
   });
 }
 
@@ -1038,11 +1097,11 @@ async function navigateTo(params) {
     if (Number.isInteger(params.windowId)) createProps.windowId = params.windowId;
     const tab = await browser.tabs.create(createProps);
     tabId = tab.id;
-    if (params.wait !== false) await waitForTabComplete(tabId, params.timeoutMs);
+    if (params.wait !== false) await waitForTabComplete(tabId, params.timeoutMs, params.url);
   } else {
     tabId = await resolveTabId(params);
     await browser.tabs.update(tabId, { url: params.url });
-    if (params.wait !== false) await waitForTabComplete(tabId, params.timeoutMs);
+    if (params.wait !== false) await waitForTabComplete(tabId, params.timeoutMs, params.url);
   }
 
   // Update cache to the tab we actually navigated


### PR DESCRIPTION
## Summary

`navigate` to a URL that only changes the fragment (`#hash`) or triggers a `history.pushState` route hangs for the full timeout (default 15s) and then rejects with `Error: Timed out waiting for page load`, even though the tab URL updates correctly.

## Environment

- Extension `browser-agent-bridge` v0.9.8 (also present in v0.9.7)
- Firefox 153, Linux

## Root cause

`waitForTabComplete` (extension/background.js) resolves only on:

```js
browser.tabs.onUpdated.addListener((updatedTabId, info) => {
  if (updatedTabId === tabId && info.status === "complete") { ... }
});
```

A navigation that only changes the URL fragment, or an SPA route via `history.pushState`, is a **same-document navigation**: Firefox does not reload the document, so `tabs.onUpdated` never fires a `status: "complete"`. The promise waits until the timeout and `navigate` rejects, despite the URL having changed.

## Reproduction

Against the running bridge (`browser` CLI), navigate to the current page then to the same page plus a new hash right after a full load:

```
browser navigate '{"url":"https://example.com/"}'
browser navigate '{"url":"https://example.com/#section"}'   # hangs ~15s, then:
# Error: Timed out waiting for page load
```

Reliability (full-nav immediately followed by a hash-nav, repeated):
- **4/5** runs timed out; with a longer loop the failure is consistent.
- `getActiveTab` after the "timeout" shows the URL **did** change to `.../#section`, confirming the navigation itself worked - only the wait rejected.

This bites any hash-routed site and in-page anchors. It's also what makes `navigate` look flaky on SPAs.

## Fix

Branch: https://github.com/vietgs03/firefox-agent-bridge/tree/fix/hash-navigation-timeout

`waitForTabComplete(tabId, timeoutMs, expectedUrl)`:

1. Also listen for `webNavigation.onReferenceFragmentUpdated` (hash) and `onHistoryStateUpdated` (pushState) on the top frame, matching the destination URL ignoring the hash so an unrelated in-page navigation doesn't resolve it early. `webNavigation` is already in the manifest permissions.
2. Pre-check with `tabs.get`: if the tab is already `complete` at the expected URL before the listeners attach (fast/cached load, or a hash change applied synchronously), resolve immediately - so a race where the event fires before the listener is attached can't hang either.
3. `navigateTo` (new-tab + same-tab) and the branch-navigation path now pass the target URL so same-document detection can match it.

```js
async function waitForTabComplete(tabId, timeoutMs = 15000, expectedUrl = null) {
  // ... onUpdated (status===complete) + onReferenceFragmentUpdated / onHistoryStateUpdated
  // ... plus a tabs.get() pre-check that resolves if already complete at expectedUrl
}
```

## Verification

Loaded the patched extension as a temporary add-on (`web-ext run`) and reran the repro:

- Hash-navigation timeouts: **4/5 -> 0/12**, each hash-nav completing in ~150-240ms instead of hanging 15s.
- Regression check: normal full navigations to a different origin still return page content as before.

Happy to open a PR from the branch.

---
Closes #9